### PR TITLE
fix: replace character limit with word limit for text generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - **Model Selection**: Choose from a variety of models to generate the text.
 - **Model Temperature**: Set the temperature of the model to control the creativity of the text.
-- **Character Limit and Language**: Set the character limit and language of the generated text.
+- **Word Limit and Language**: Set the word limit and language of the generated text.
 
 ## Usage  
 
@@ -22,7 +22,7 @@ The Action multiple inputs, some are required and some are optional:
 2. **`gemini-api-key`** (Required) – The Gemini API key used for authentication and text generation. You can obtain it from the [Gemini API](https://ai.google.dev/gemini-api/docs/api-key) page.  
 3. **`user-prompt`** (Optional) – The prompt used to generate the text. The default is:  
 4. **`gemini-model`** (Optional) – The model used to generate the text. The default is: `gemini-1.5-flash`. We can use other Gemini models like `gemini-2.0-flash-exp`, `gemini-1.5-flash-8b`, `gemini-1.5-pro`, `gemini-1.0-pro`. A complete list of models can be found [here](https://ai.google.dev/gemini-api/docs/models/gemini).
-5. **`character-limit`** (Optional) – The character limit for the generated text. The default is 300.
+5. **`word-limit`** (Optional) – The word limit for the generated text. The default is 200.
 6. **`output-language`** (Optional) – The language of the generated text. The default is `english`.
 7. **`model-temp`** (Optional) – The temperature of the model. The default is 0.5. We can set the temperature between 0.1 to 1.0. The lower the temperature, the more deterministic the model will be. The higher the temperature, the more creative the model will be.
 
@@ -72,7 +72,7 @@ jobs:
           user-prompt: "How to become a better developer?" # Optional
           gemini-model: "gemini-1.5-flash" # Optional
           output-language: "spanish" # Optional
-          character-limit: 450 # Optional
+          word-limit: 250 # Optional
           model-temp: 0.5 # Optional
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,10 @@ inputs:
     description: 'Model to use for the response. The default is gemini-1.5-flash'
     required: false
     default: "gemini-1.5-flash"
-  character-limit:
-    description: 'Character limit for the response'
+  word-limit:
+    description: 'Word limit for the response'
     required: false
-    default: "300"
+    default: "200"
   output-language:
     description: 'Output language for the response'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -33086,7 +33086,7 @@ async function run() {
     const token = (0, core.getInput)("github-token", { required: true });
     const geminiApiKey = (0, core.getInput)("gemini-api-key", { required: true });
     const userPrompt = (0, core.getInput)("user-prompt");
-    const characterLimit = (0, core.getInput)("character-limit");
+    const wordLimit = (0, core.getInput)("word-limit");
     const outputLanguage = (0, core.getInput)("output-language");
     const geminiModel = (0, core.getInput)("gemini-model");
     const modelTemperature = (0, core.getInput)("model-temp");
@@ -33102,7 +33102,7 @@ async function run() {
     const commentBody = await geminiCall(
       geminiApiKey,
       userPrompt,
-      characterLimit,
+      wordLimit,
       outputLanguage,
       geminiModel,
       modelTemperature
@@ -33118,7 +33118,7 @@ async function run() {
   }
 }
 
-async function geminiCall(geminiApiKey, userPrompt, characterLimit, outputLanguage, geminiModel, modelTemperature) {
+async function geminiCall(geminiApiKey, userPrompt, wordLimit, outputLanguage, geminiModel, modelTemperature) {
   try {
     const genAI = new GoogleGenerativeAI(geminiApiKey);
     const model = genAI.getGenerativeModel({ model: geminiModel });
@@ -33129,7 +33129,7 @@ async function geminiCall(geminiApiKey, userPrompt, characterLimit, outputLangua
           role: "user",
           parts: [
             {
-              text: userPrompt + " in " + outputLanguage + " in " + characterLimit + " characters.",
+              text: userPrompt + " in " + outputLanguage + " in " + wordLimit + " words",
             },
           ],
         },

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ async function run() {
     const token = getInput("github-token", { required: true });
     const geminiApiKey = getInput("gemini-api-key", { required: true });
     const userPrompt = getInput("user-prompt");
-    const characterLimit = getInput("character-limit");
+    const wordLimit = getInput("word-limit");
     const outputLanguage = getInput("output-language");
     const geminiModel = getInput("gemini-model");
     const modelTemperature = getInput("model-temp");
@@ -23,7 +23,7 @@ async function run() {
     const commentBody = await geminiCall(
       geminiApiKey,
       userPrompt,
-      characterLimit,
+      wordLimit,
       outputLanguage,
       geminiModel,
       modelTemperature
@@ -39,7 +39,7 @@ async function run() {
   }
 }
 
-async function geminiCall(geminiApiKey, userPrompt, characterLimit, outputLanguage, geminiModel, modelTemperature) {
+async function geminiCall(geminiApiKey, userPrompt, wordLimit, outputLanguage, geminiModel, modelTemperature) {
   try {
     const genAI = new GoogleGenerativeAI(geminiApiKey);
     const model = genAI.getGenerativeModel({ model: geminiModel });
@@ -50,7 +50,7 @@ async function geminiCall(geminiApiKey, userPrompt, characterLimit, outputLangua
           role: "user",
           parts: [
             {
-              text: userPrompt + " in " + outputLanguage + " in " + characterLimit + " characters.",
+              text: userPrompt + " in " + outputLanguage + " in " + wordLimit + " words",
             },
           ],
         },


### PR DESCRIPTION
### Changes proposed

Replace character limit with word limit for text generation. So now the `character-limit` option is deprecated, and in place of it, the users can use the `word-limit` option.
