### PR TITLE
fix: use `gemini-2.0-flash` as the default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Action multiple inputs, some are required and some are optional:
    *"Share an open-source tip in 2 to 3 lines to help developers improve their workflow."* You can find this in the `action.yml` file.  
 2. **`gemini-api-key`** (Required) – The Gemini API key used for authentication and text generation. You can obtain it from the [Gemini API](https://ai.google.dev/gemini-api/docs/api-key) page.  
 3. **`user-prompt`** (Optional) – The prompt used to generate the text. The default is:  
-4. **`gemini-model`** (Optional) – The model used to generate the text. The default is: `gemini-1.5-flash`. We can use other Gemini models like `gemini-2.0-flash-exp`, `gemini-1.5-flash-8b`, `gemini-1.5-pro`, `gemini-1.0-pro`. A complete list of models can be found [here](https://ai.google.dev/gemini-api/docs/models/gemini).
+4. **`gemini-model`** (Optional) – The model used to generate the text. The default is: `gemini-2.0-flash`. We can use other Gemini models like `gemini-1.5-flash`, `gemini-1.5-flash-8b`, `gemini-1.5-pro`, `gemini-1.0-pro`. A complete list of models can be found [here](https://ai.google.dev/gemini-api/docs/models/gemini).
 5. **`word-limit`** (Optional) – The word limit for the generated text. The default is 200.
 6. **`output-language`** (Optional) – The language of the generated text. The default is `english`.
 7. **`model-temp`** (Optional) – The temperature of the model. The default is 0.5. We can set the temperature between 0.1 to 1.0. The lower the temperature, the more deterministic the model will be. The higher the temperature, the more creative the model will be.
@@ -70,7 +70,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Required
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }} # Required
           user-prompt: "How to become a better developer?" # Optional
-          gemini-model: "gemini-1.5-flash" # Optional
+          gemini-model: "gemini-2.0-flash" # Optional
           output-language: "spanish" # Optional
           word-limit: 250 # Optional
           model-temp: 0.5 # Optional

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,9 @@ inputs:
     required: false
     default: 'Share an open-source tip in 2 to 3 lines to help developers improve their workflow'
   gemini-model:
-    description: 'Model to use for the response. The default is gemini-1.5-flash'
+    description: 'Model to use for the response. The default is gemini-2.0-flash'
     required: false
-    default: "gemini-1.5-flash"
+    default: "gemini-2.0-flash"
   word-limit:
     description: 'Word limit for the response'
     required: false


### PR DESCRIPTION
### Changes proposed

Update the Action to use `gemini-2.0-flash` as the default model in place of `gemini-1.5-flash`

### Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] I have built the code with `num run build` and run `npm run format` before pushing the code.
- [x] I have read the [CONTRIBUTING.md]([../CONTRIBUTING.md](https://github.com/Pradumnasaraf/pullprompt/blob/main/CONTRIBUTING.md)) document and I have an assigned issue to work on the changes outgoing via this PR.
- [x] The title of my pull request is a short description of the requested changes.
- [x] I have updated the README/documentation accordingly about the changes/features (if applicable).
- [x] Update the Action examples in the README if the changes are related to the Action (fixes, features, etc).
